### PR TITLE
Refactor: Implement global TopAppBar and normalize Scaffold usage

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/devstudio/receipto/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/devstudio/receipto/AppNavigation.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.MailOutline
 import androidx.compose.material.icons.filled.Settings
@@ -18,7 +19,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
@@ -130,17 +134,53 @@ fun AppNavigation() {
             titleContentColor = MaterialTheme.colorScheme.onErrorContainer
         )
     }
+
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
+    val topBarTitle = when (currentRoute) {
+        RECEIPTS_LIST -> "Receipts"
+        SETTINGS -> "Settings"
+        Routes.ADD_RECEIPT -> "Add Receipt"
+        Routes.EDIT_RECEIPT_WITH_ID -> "Edit Receipt"
+        else -> ""
+    }
+
+    val showAppBar = currentRoute in listOf(
+        RECEIPTS_LIST,
+        SETTINGS,
+        Routes.ADD_RECEIPT,
+        Routes.EDIT_RECEIPT_WITH_ID
+    )
+
     Scaffold(
+        topBar = {
+            if (showAppBar) {
+                TopAppBar(
+                    title = { Text(topBarTitle) },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.background,
+                        titleContentColor = MaterialTheme.colorScheme.onBackground
+                    ),
+                    navigationIcon = {
+                        if (currentRoute != RECEIPTS_LIST) {
+                            IconButton(onClick = { navController.popBackStack() }) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                    contentDescription = "Back"
+                                )
+                            }
+                        }
+                    }
+                )
+            }
+        },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         bottomBar = {
-            val currentRoute =
-                navController.currentBackStackEntryAsState().value?.destination?.route
             if (currentRoute == RECEIPTS_LIST || currentRoute == SETTINGS) {
                 BottomNavigationBar(navController)
             }
         }, floatingActionButton = {
-            val currentRoute =
-                navController.currentBackStackEntryAsState().value?.destination?.route
             if (currentRoute == RECEIPTS_LIST) {
                 FloatingActionButton(
                     onClick = { navController.navigate(Routes.ADD_RECEIPT) },

--- a/composeApp/src/commonMain/kotlin/com/devstudio/receipto/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/devstudio/receipto/ui/SettingsScreen.kt
@@ -16,12 +16,9 @@ import androidx.compose.material.icons.filled.MailOutline
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Policy
 import androidx.compose.material.icons.filled.Description
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,10 +27,8 @@ import androidx.compose.ui.unit.dp
 
 
 // Main Composable for the Settings Screen
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    onBackClicked: () -> Unit = {},
     onAccountClicked: () -> Unit = {},
     onAppearanceClicked: () -> Unit = {},
     onNotificationsClicked: () -> Unit = {},
@@ -45,17 +40,12 @@ fun SettingsScreen(
     onTermsOfServiceClicked: () -> Unit = {},
     onPrivacyPolicyClicked: () -> Unit = {},
 ) {
-    Scaffold(topBar = {
-        TopAppBar(
-            title = { Text("Settings") },
-        )
-    }) { paddingValues ->
-        LazyColumn(
-            modifier = Modifier.fillMaxSize().padding(paddingValues).padding(horizontal = 16.dp)
-        ) {
-            item {
-                Spacer(modifier = Modifier.height(16.dp))
-                SettingsSectionHeader("General")
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)
+    ) {
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+            SettingsSectionHeader("General")
                 SettingsItem(
                     icon = Icons.Default.AccountCircle,
                     title = "Account",

--- a/composeApp/src/commonMain/kotlin/com/devstudio/receipto/ui/screens/AddReceiptScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/devstudio/receipto/ui/screens/AddReceiptScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material3.Button
@@ -37,17 +36,13 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -58,7 +53,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -77,49 +71,17 @@ fun EditReceiptScreen(
     val currentReceipt by viewModel.currentReceipt.collectAsState()
     val openDatePickerDialog = remember { mutableStateOf(false) }
     val openReminderDatePickerDialog = remember { mutableStateOf(false) }
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 
     currentReceipt?.let { receipt ->
-        Scaffold(
+        // Column is now the root composable content when currentReceipt is available
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .nestedScroll(scrollBehavior.nestedScrollConnection),
-            topBar = {
-                TopAppBar(
-                    title = {
-                        Text(
-                            text = "Edit Receipt",
-                            color = Color.White,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 20.sp
-                        )
-                    },
-                    navigationIcon = {
-                        IconButton(onClick = { navController.popBackStack() }) {
-                            Icon(
-                                imageVector = Icons.Default.Close,
-                                contentDescription = "Close",
-                                tint = Color.White
-                            )
-                        }
-                    },
-                    colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = Color(0xFF2C2C2C)
-                    ),
-                    scrollBehavior = scrollBehavior
-                )
-            },
-            containerColor = Color(0xFF1A1A1A)
-        ) { paddingValues ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .padding(horizontal = 16.dp)
-                    .verticalScroll(rememberScrollState())
-            ) {
-                Spacer(modifier = Modifier.height(24.dp))
-
+                .padding(horizontal = 16.dp) // Apply horizontal padding; vertical is handled by NavHost
+                .verticalScroll(rememberScrollState())
+                .background(Color(0xFF1A1A1A)) // Apply background color here if needed for the content area
+        ) {
+            Spacer(modifier = Modifier.height(24.dp))
                 // Name
                 Text(
                     text = "Name",
@@ -143,8 +105,6 @@ fun EditReceiptScreen(
                     ),
                     shape = RoundedCornerShape(12.dp)
                 )
-                Spacer(modifier = Modifier.height(24.dp))
-
                 // Amount
                 Text(
                     text = "Amount",
@@ -172,8 +132,6 @@ fun EditReceiptScreen(
                     ),
                     shape = RoundedCornerShape(12.dp)
                 )
-                Spacer(modifier = Modifier.height(24.dp))
-
                 // Date
                 Text(
                     text = "Date",
@@ -208,8 +166,6 @@ fun EditReceiptScreen(
                     ),
                     shape = RoundedCornerShape(12.dp)
                 )
-                Spacer(modifier = Modifier.height(24.dp))
-
                 // Reminder Date
                 Text(
                     text = "Reminder Date",
@@ -244,8 +200,6 @@ fun EditReceiptScreen(
                     ),
                     shape = RoundedCornerShape(12.dp)
                 )
-                Spacer(modifier = Modifier.height(24.dp))
-
                 // Reason
                 Text(
                     text = "Reason",
@@ -271,8 +225,6 @@ fun EditReceiptScreen(
                     ),
                     shape = RoundedCornerShape(12.dp)
                 )
-                Spacer(modifier = Modifier.height(32.dp))
-
                 // Receipts Section
                 Text(
                     text = "Receipts",
@@ -331,8 +283,6 @@ fun EditReceiptScreen(
                     }
                 }
 
-                Spacer(modifier = Modifier.height(48.dp))
-
                 // Bottom Buttons
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -385,7 +335,6 @@ fun EditReceiptScreen(
 
                 Spacer(modifier = Modifier.height(32.dp))
             }
-        }
     }
 
     if (openDatePickerDialog.value) {

--- a/composeApp/src/commonMain/kotlin/com/devstudio/receipto/ui/screens/ReceiptsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/devstudio/receipto/ui/screens/ReceiptsScreen.kt
@@ -42,19 +42,6 @@ fun ReceiptsScreen(
     Column(
         modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)
     ) {
-        TopAppBar(
-            title = {
-                Text(
-                    text = "Receipts",
-                    color = MaterialTheme.colorScheme.onBackground,
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 20.sp
-                )
-            }, colors = TopAppBarDefaults.topAppBarColors(
-                containerColor = MaterialTheme.colorScheme.background
-            )
-        )
-        Spacer(modifier = Modifier.height(16.dp))
         SearchBarComponent(
             searchQuery = searchQuery,
             onSearchQueryChange = viewModel::updateSearchQuery,


### PR DESCRIPTION
This commit refactors the application to use a single, global TopAppBar managed within `AppNavigation.kt`. This addresses an initial issue of excess padding on the ReceiptsScreen and incorporates your feedback to make the TopAppBar consistent across multiple screens.

Key changes:
- Removed local TopAppBar instances from `ReceiptsScreen`, `SettingsScreen`, and `EditReceiptScreen`.
- Removed local Scaffold instances from `SettingsScreen` and `EditReceiptScreen`, relying on the main Scaffold in `AppNavigation.kt`.
- The global TopAppBar in `AppNavigation.kt` now dynamically updates its title based on the current route:
    - "Receipts" for ReceiptsScreen
    - "Settings" for SettingsScreen
    - "Add Receipt" for AddReceiptScreen
    - "Edit Receipt" for EditReceiptScreen
- A navigation icon (back arrow) is now displayed in the global TopAppBar for Settings, Add Receipt, and Edit Receipt screens, handling back navigation. ReceiptsScreen does not show a navigation icon.
- Ensured proper padding is applied to screen content from the global Scaffold via NavHost.

This approach centralizes app bar logic, improves UI consistency, and resolves the original padding problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic top app bar that displays context-aware titles and navigation options based on the current screen.

- **Refactor**
  - Updated several screens to remove their individual top app bars and scaffolds, consolidating navigation and titles into the main app bar for a more consistent layout.
  - Adjusted screen layouts to use simpler containers and padding, improving visual consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->