### PR TITLE
Fix: Prevent global loading spinner when closing receipt edit screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/devstudio/receipto/ui/screens/AddReceiptScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/devstudio/receipto/ui/screens/AddReceiptScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -74,6 +75,11 @@ fun EditReceiptScreen(
     navController: NavController,
     viewModel: ReceiptViewModel
 ) {
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.cancelOngoingUserDataOperations()
+        }
+    }
     val currentReceipt by viewModel.currentReceipt.collectAsState()
     val openDatePickerDialog = remember { mutableStateOf(false) }
     val openReminderDatePickerDialog = remember { mutableStateOf(false) }


### PR DESCRIPTION
The global loading spinner in AppNavigation would persist if you closed the EditReceiptScreen (via the 'X' button) while a save or delete operation was still in progress. This was because the isLoading flag in ReceiptViewModel was not reset when the screen was dismissed prematurely.

This commit addresses the issue by:
1. Modifying ReceiptViewModel to track the Jobs of ongoing asynchronous operations (add, update, delete receipt, upload image).
2. Introducing a `cancelOngoingUserDataOperations()` method in ReceiptViewModel that cancels these jobs and resets the `isLoading` state in `uiState`.
3. Calling `cancelOngoingUserDataOperations()` from the `onCleared()` method of ReceiptViewModel for general cleanup.
4. Adding a `DisposableEffect` to `EditReceiptScreen`. The `onDispose` block of this effect calls `viewModel.cancelOngoingUserDataOperations()`, ensuring that if the screen is closed while an operation it initiated is still running, the operation is cancelled and the loading state is reset, preventing the global spinner from persisting on the previous screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Ongoing user data operations are now automatically cancelled when navigating away from the receipt editing screen, improving app responsiveness and reliability.

- **Bug Fixes**
  - Prevented overlapping or duplicate user data operations, ensuring smoother and more predictable behavior during receipt actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->